### PR TITLE
Update link of kosen-karuta in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - [高専一覧](https://codeforkosen.github.io/kosen-opendata/sample/kosen.html)
 - [KOSEN emblem 一覧(由来有り)](https://codeforkosen.github.io/kosen-opendata/sample/kosen_emblem.html)
-- [KOSEN emblem 一覧(かるた版)](https://github.com/daiking1756/kosen-karuta)
+- [高専かるた](https://codeforkosen.github.io/kosen-apps/karuta.html)
 - [CSV オープンデータ](https://codeforkosen.github.io/kosen-opendata/data/kosen.csv)
 - [学校コード一覧(高専、大学、短大)](https://codeforkosen.github.io/kosen-opendata/data/mext/scode.csv) - [文部科学省　学校コード：文部科学省](https://www.mext.go.jp/b_menu/toukei/mext_01087.html) [令和5年5月1日時点（暫定版） 大学、短期大学、高等専門学校](https://www.mext.go.jp/content/20230731-mxt_chousa01-000011635_5.xlsx) をCSVに変換
 


### PR DESCRIPTION
https://github.com/daiking1756/kosen-karuta から https://codeforkosen.github.io/kosen-apps/karuta.html へリンクを更新しています。
更新前のリンクのgithub pagesは既に非公開としており、https://github.com/daiking1756/kosen-karuta のREADME.mdにも、こちらへ移行した旨を記載しております。